### PR TITLE
fix: Explicitly set SQLite URI for local dev in app.py main entrypoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -503,8 +503,9 @@ def traffic_update(bus_id):
 
 # Run the application
 if __name__ == '__main__':
+    # Use SQLite for local development
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///happytrails.db'
     app.run(debug=True)
-app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///happytrails.db'
 
 # Make sure it points to the correct location
 # If you want the database in a specific folder, use absolute paths:


### PR DESCRIPTION
@Kavlin-Kaur This PR updates `app.py` to guarantee that `SQLALCHEMY_DATABASE_URI` is set to `'sqlite:///happytrails.db'` when running the app locally via `__main__`:
- Adds an explicit assignment of the SQLite URI before `app.run(debug=True)`
- Ensures local environments always have a working database connection, regardless of previous config
- Helps avoid startup errors for new developers and simplifies onboarding/setup

No changes to production or deployment logic—this only impacts local development.

Closes #8 